### PR TITLE
Output error messages to STDERR

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var sys = require("sys");
 var fs = require("fs");
 var parser = require("./jsonlint").parser;
 var options = require("nomnom")
@@ -41,7 +40,7 @@ function parse (source) {
                     parser.parse(source); 
     return JSON.stringify(parsed,null,options.indent);
   } catch (e) {
-    sys.puts(e);
+    console.error(e.message);
     process.exit(1);
   }
 }
@@ -54,7 +53,7 @@ function main (args) {
     if (options.inplace) {
       fs.writeSync(fs.openSync(path,'w+'), source, 0, "utf8");
     } else {
-      sys.puts(source);
+      console.log(source);
     }
   } else {
     var stdin = process.openStdin();
@@ -64,7 +63,7 @@ function main (args) {
       source += chunk.toString('utf8');
     });
     stdin.on('end', function () {
-      sys.puts(parse(source));
+      console.log(parse(source));
     });
   }
 }


### PR DESCRIPTION
  So we can output only the error messages like this:
  jsonlint example.json > /dev/null
