### PR TITLE
added compact output option to allow integrating into IDEs more easily (like Vim)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,6 +11,7 @@ var options = require("nomnom")
       help: "file to parse; otherwise uses stdin"
     },
     version: {
+      flag : true,
       string: '-v, --version',
       help: 'print version and exit',
       callback: function() {
@@ -18,30 +19,46 @@ var options = require("nomnom")
       }
     },
     sort : {
+      flag : true,
       string: '-s, --sort-keys',
       help: 'sort object keys'
     },
     inplace : {
+      flag : true,
       string: '-i, --in-place',
       help: 'overwrite the file'
     },
     indent : {
       string: '-t CHAR, --indent CHAR',
-      default: "  ",
+      "default": "  ",
       help: 'character(s) to use for indentation'
+    },
+    compact : {
+        flag : true,
+        string: '-c, --compact',
+        help : 'compact error display'
     }
   })
   .parseArgs();
 
+if (options.compact) {
+    var fileName = options.file? options.file + ': ' : '';
+    parser.parseError = parser.lexer.parseError = function(str, hash) {
+        util.puts(fileName + 'line '+ hash.loc.first_line +', col '+ hash.loc.last_column +', found: \''+ hash.token +'\' - expected: '+ hash.expected.join(', ') +'.');
+        throw new Error(str);
+    };
+}
 
 function parse (source) {
   try {
     var parsed = options.sort ?
                     sortObject(parser.parse(source)) :
-                    parser.parse(source); 
+                    parser.parse(source);
     return JSON.stringify(parsed,null,options.indent);
   } catch (e) {
-    util.puts(e);
+    if (! options.compact) {
+        util.puts(e);
+    }
     process.exit(1);
   }
 }
@@ -49,7 +66,7 @@ function parse (source) {
 function main (args) {
   var source = '';
   if (options.file) {
-    var path = require('path').join(process.cwd(), options.file); 
+    var path = require('path').join(process.cwd(), options.file);
     source = parse(fs.readFileSync(path, "utf8"));
     if (options.inplace) {
       fs.writeSync(fs.openSync(path,'w+'), source, 0, "utf8");

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint",
     "jsonlint"
   ],
-  "version": "1.2.1",
+  "version": "1.2.1+",
   "preferGlobal": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
I wasn't editing that many JSON files since I created the feature request, but this week I used the JSONLint site too many times so today I decided to spend a few minutes tweaking the CLI to work as I need it..

main reason was to provide an easy way to parse the error messages so I can use it to validate JSON files during save inside Vim by using the [syntastic plugin](https://github.com/scrooloose/syntastic)  - see #10

I coded the JSON syntax checker for syntastic a couple minutes ago, will just wait this change to be merged and published to NPM so I can ask for a pull request on syntastic as well.

thx
