### PR TITLE
Fix for #16 Absolute path parsing via the CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,7 +66,7 @@ function parse (source) {
 function main (args) {
   var source = '';
   if (options.file) {
-    var path = require('path').join(process.cwd(), options.file);
+    var path = require('path').resolve(options.file);
     source = parse(fs.readFileSync(path, "utf8"));
     if (options.inplace) {
       fs.writeSync(fs.openSync(path,'w+'), source, 0, "utf8");


### PR DESCRIPTION
Now both absolute paths and paths relative to your CWD work. I tried to
add a test case for this, but I couldn't figure out a clean way to just
test the CLI options. Suggestions for this would be great if you think
a test is needed.
