### PR TITLE
Add bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "jsonlint",
+  "version": "1.6.0",
+  "main": "lib/jsonlint.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "scripts",
+    "src",
+    "test",
+    "web",
+    "package.json",
+    "Makefile",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
Hi,

Firstly, thanks very much for jsonlint -- we use it as to add syntax highlighting errors to our CodeMirror editors in our web application.

I'd now like to be able to install/package jsonlint via [bower](http://bower.io), and so I've added the attached bower manifest file. Bower seems to be gaining traction as the package manager for Javascript web applications (much as NPM is used for Node.js applications), so it'd be great to see support for bower in jsonlint.

Cheers,
Louis.
