### PR TITLE
Sort objects which are descendants of arrays

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -154,13 +154,21 @@ function main (args) {
 
 // from http://stackoverflow.com/questions/1359761/sorting-a-json-object-in-javascript
 function sortObject(o) {
+  var sorted;
+
+  if (Object.prototype.toString.call(o) === '[object Array]') {
+    sorted = [];
+    for (var i = 0; i < o.length; i++) {
+      sorted[i] = sortObject(o[i]);
+    }
+    return sorted;
+  }
+
   if (Object.prototype.toString.call(o) !== '[object Object]') {
     return o;
   }
 
-  var sorted = {},
-  key, a = [];
-
+  var key, a = [];
   for (key in o) {
     if (o.hasOwnProperty(key)) {
       a.push(key);
@@ -169,6 +177,7 @@ function sortObject(o) {
 
   a.sort();
 
+  sorted = {};
   for (key = 0; key < a.length; key++) {
     sorted[a[key]] = sortObject(o[a[key]]);
   }


### PR DESCRIPTION
Currently, the sort option causes only objects which are not descendants of arrays to be sorted.  I contend it would be more useful to sort all objects, rather than only objects which are not descendants of arrays.  This pull request implements that change.  I look forward to your thoughts.
