### PR TITLE
Set exit status when quiet

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -148,7 +148,7 @@ function main (args) {
       source += chunk.toString('utf8');
     });
     stdin.on('end', function () {
-      var parsed = parse(source)
+      var parsed = parse(source);
       if (! options.quiet) {console.log(parsed)};
     });
   }


### PR DESCRIPTION
Right now in quiet mode the json is never parsed - this will allow it to parse and set the exit status without logging the error.
