### PR TITLE
implementation of a diff feature

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ var path = require("path");
 var parser = require("./jsonlint").parser;
 var JSV = require("JSV").JSV;
 var formatter = require("./formatter.js").formatter;
+var diff = require("./diff.js");
 
 var options = require("nomnom")
   .script("jsonlint")
@@ -61,6 +62,20 @@ var options = require("nomnom")
       flag:  true,
       string: '-p, --pretty-print',
       help: 'force pretty printing even if invalid'
+    },
+    diff: {
+      flag: true,
+      string: '-d, --diff',
+      help: 'only compare the input to the generated output (must not be used with --inplace or --compact)'
+    },
+    ignoreTrailingNewLine: {
+      flag: true,
+      string: '-n, --ignore-trailing-newline',
+      help: 'if --diff is set, a trailing new line in the source is ignored during comparison'
+    },
+    diffContext: {
+      string: '-x INT, --diff-context INT',
+      help: 'if --diff is set, the context printed out in error case depends on the passed number of lines'
     }
   }).parse();
 
@@ -132,11 +147,13 @@ function main () {
   var source = '';
   if (options.file) {
     var json = path.normalize(options.file);
-    source = parse(fs.readFileSync(json, "utf8"));
+    source = fs.readFileSync(json, "utf8");
+    var result = parse(source);
+    diff(source, result, options);
     if (options.inplace) {
-      fs.writeSync(fs.openSync(json,'w+'), source, 0, "utf8");
-    } else {
-      if (! options.quiet) { console.log(source)};
+      fs.writeSync(fs.openSync(json,'w+'), result, 0, "utf8");
+    } else if (! options.quiet) {
+      console.log(result);
     }
   } else {
     var stdin = process.openStdin();
@@ -146,7 +163,11 @@ function main () {
       source += chunk.toString('utf8');
     });
     stdin.on('end', function () {
-      if (! options.quiet) {console.log(parse(source))};
+      result = parse(source);
+      diff(source, result, options);
+      if (! options.quiet) {
+        console.log(result);
+      }
     });
   }
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -37,30 +37,30 @@ var options = require("nomnom")
       help: 'character(s) to use for indentation'
     },
     compact : {
-        flag : true,
-        string: '-c, --compact',
-        help : 'compact error display'
+      flag : true,
+      string: '-c, --compact',
+      help : 'compact error display'
     },
     validate : {
-        string: '-V, --validate',
-        help : 'a JSON schema to use for validation'
+      string: '-V, --validate',
+      help : 'a JSON schema to use for validation'
     },
     env : {
-        string: '-e, --environment',
-        "default": "json-schema-draft-03",
-        help: 'which specification of JSON Schema the validation file uses'
+      string: '-e, --environment',
+      "default": "json-schema-draft-03",
+      help: 'which specification of JSON Schema the validation file uses'
     },
     quiet: {
-        flag:  true,
-        key: "value",
-        string: '-q, --quiet',
-        "default": false,
-        help: 'do not print the parsed json to STDOUT'
+      flag:  true,
+      key: "value",
+      string: '-q, --quiet',
+      "default": false,
+      help: 'do not print the parsed json to STDOUT'
     },
     forcePrettyPrint: {
-        flag:  true,
-        string: '-p, --pretty-print',
-        help: 'force pretty printing even if invalid'
+      flag:  true,
+      string: '-p, --pretty-print',
+      help: 'force pretty printing even if invalid'
     }
   }).parse();
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -128,7 +128,7 @@ function schemaError (str, err) {
          "\ndetails: " + JSON.stringify(err.details);
 }
 
-function main (args) {
+function main () {
   var source = '';
   if (options.file) {
     var json = path.normalize(options.file);
@@ -176,4 +176,4 @@ function sortObject(o) {
   return sorted;
 }
 
-main(process.argv.slice(1));
+main();

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,0 +1,55 @@
+var LINE_FEED = process.platform === 'win32' ? '\r\n' : '\n';
+
+function printContext(lines, errorLineNumber, contextWindow, fileName) {
+  var firstLine = errorLineNumber - contextWindow;
+  if (firstLine < 0) {
+    firstLine = 0;
+  } else if (firstLine >= lines.length) {
+      firstLine = lines.length - 1;
+  }
+  var lastLine = errorLineNumber + contextWindow;
+  if (lastLine >= lines.length) {
+    lastLine = lines.length - 1;
+  }
+  console.log('--- ' + fileName + ': ' + firstLine + ', ' + lastLine + ' ---');
+  for (var line = firstLine; line <= lastLine; ++line) {
+    if (line === errorLineNumber && contextWindow !== 0) {
+      console.log('!' + lines[line]);
+    } else {
+      console.log(' ' + lines[line]);
+    }
+  }
+}
+
+function printDiff (linesSource, linesResult, errorLineNumber, options) {
+  var contextWindow = typeof options.diffContext === 'number' && options.diffContext >= 0 ?
+          options.diffContext : 0;
+  printContext(linesSource, errorLineNumber, contextWindow, 'source');
+  printContext(linesResult, errorLineNumber, contextWindow, 'result');
+}
+
+function makeDiff (source, result, options) {
+  var linesSource = source.split(LINE_FEED);
+  var linesResult = result.split(LINE_FEED);
+  if(options.diff) {
+    for (var lineNumber = 0; lineNumber !== linesSource.length &&
+                 lineNumber !== linesResult.length; ++lineNumber) {
+      if (linesSource[lineNumber] !== linesResult[lineNumber]) {
+        break;
+      }
+    }
+    if ((lineNumber === linesSource.length || (lineNumber === linesSource.length - 1 &&
+                                                linesSource[linesSource.length - 1] === '' &&
+                                                options.ignoreTrailingNewLine === true)) &&
+        lineNumber === linesResult.length) {
+      process.exit(0);
+    } else {
+      if (! options.quiet) {
+          printDiff(linesSource, linesResult, lineNumber, options);
+      }
+      process.exit(1);
+    }
+  }
+}
+
+module.exports = exports = makeDiff;


### PR DESCRIPTION
This allows to compare the output with the input data. In addition to validate only the semantics of the JSON data a diff-like feature also allows to validate the style of the data (e.g. spacing). This means it can be used in an automated build chain that also checks .json files for style rules based on jsonlint.

The following feature are offered:
* exits with 0 and no content on stdout in case of success if called with --diff
* exists with 1 and a diff-like output on stdout if --quiet is not set but --diff is set
* exists with 1 and not output on stdout if --quiet and --diff is set
* allows to set the context window (in lines) that is printed in error case
* allows to ignore a trailing line feed in the source to be compliant to the output
