### PR TITLE
Negative indentLevel throwing RangeError when prettyPrinting

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -13,6 +13,7 @@
 var formatter = (function () {
 
     function repeat(s, count) {
+        count = count < 0 ? 0 : count;
         return new Array(count + 1).join(s);
     }
 


### PR DESCRIPTION
Believe it or not this is from a real world example. Found on http://pro.jsonlint.com and followed back here.

Simplest replication I can find:

```
air:~$ cat bad.json
{
        "key": "value"
}
}
}
air:~$ jsonlint -p bad.json
[RangeError: Invalid array length]
undefined
```

Without pretty printing it works fine as the formatter isn't used:

```
air:~$ jsonlint bad.json
[Error: Parse error on line 3:
...  "key": "value"}}}
--------------------^
Expecting 'EOF', got '}']
```

My fix is to force the count value to zero inside jsl.format.repeat if it happens to be negative, which gives the following output:

```
air:~$ jsonlint -p bad.json
[Error: Parse error on line 3:
...  "key": "value"}}}
--------------------^
Expecting 'EOF', got '}']
{
  "key": "value"
}
}
}
```