### PR TITLE
Diff feature

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ var path = require("path");
 var parser = require("./jsonlint").parser;
 var JSV = require("JSV").JSV;
 var formatter = require("./formatter.js").formatter;
+var diff = require("./diff.js");
 
 var options = require("nomnom")
   .script("jsonlint")
@@ -61,6 +62,25 @@ var options = require("nomnom")
       flag:  true,
       string: '-p, --pretty-print',
       help: 'force pretty printing even if invalid'
+    },
+    diff: {
+      flag: true,
+      string: '-d, --diff',
+      help: 'only compare the input to the generated output (must not be used with --inplace or --compact)'
+    },
+    diffContext: {
+      string: '-x INT, --diff-context INT',
+      help: 'if --diff is set, the context printed out in error case depends on the passed number of lines'
+    },
+    ignoreTrailingNewLines: {
+      string: '--ignore-trailing-newlines INT',
+      default: 0,
+      help: 'if --diff is set, up to INT trailing new lines in the source are ignored during comparison'
+    },
+    ignoreEmptyLines: {
+      string: "--ignore-empty-lines INT",
+      default: 0,
+      help: "if --diff is set, up to INT consecutive empty lines on the source (except trailing new lines) are ignored during comparison"
     }
   }).parse();
 
@@ -132,11 +152,14 @@ function main () {
   var source = '';
   if (options.file) {
     var json = path.normalize(options.file);
-    source = parse(fs.readFileSync(json, "utf8"));
-    if (options.inplace) {
-      fs.writeSync(fs.openSync(json,'w+'), source, 0, "utf8");
-    } else {
-      if (! options.quiet) { console.log(source)};
+    source = fs.readFileSync(json, "utf8");
+    var result = parse(source);
+    if (options.diff) {
+      diff(source, result, options);
+    } else if (options.inplace) {
+      fs.writeSync(fs.openSync(json,'w+'), result, 0, "utf8");
+    } else if (! options.quiet) {
+      console.log(result);
     }
   } else {
     var stdin = process.openStdin();
@@ -146,7 +169,12 @@ function main () {
       source += chunk.toString('utf8');
     });
     stdin.on('end', function () {
-      if (! options.quiet) {console.log(parse(source))};
+      result = parse(source);
+      if (options.diff) {
+        diff(source, result, options);
+      } else if (! options.quiet) {
+        console.log(result);
+      }
     });
   }
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -33,34 +33,34 @@ var options = require("nomnom")
     },
     indent : {
       string: '-t CHAR, --indent CHAR',
-      "default": "  ",
+      default: "  ",
       help: 'character(s) to use for indentation'
     },
     compact : {
-        flag : true,
-        string: '-c, --compact',
-        help : 'compact error display'
+      flag : true,
+      string: '-c, --compact',
+      help : 'compact error display'
     },
     validate : {
-        string: '-V, --validate',
-        help : 'a JSON schema to use for validation'
+      string: '-V, --validate',
+      help : 'a JSON schema to use for validation'
     },
     env : {
-        string: '-e, --environment',
-        "default": "json-schema-draft-03",
-        help: 'which specification of JSON Schema the validation file uses'
+      string: '-e, --environment',
+      default: "json-schema-draft-03",
+      help: 'which specification of JSON Schema the validation file uses'
     },
     quiet: {
-        flag:  true,
-        key: "value",
-        string: '-q, --quiet',
-        "default": false,
-        help: 'do not print the parsed json to STDOUT'
+      flag:  true,
+      key: "value",
+      string: '-q, --quiet',
+      default: false,
+      help: 'do not print the parsed json to STDOUT'
     },
     forcePrettyPrint: {
-        flag:  true,
-        string: '-p, --pretty-print',
-        help: 'force pretty printing even if invalid'
+      flag:  true,
+      string: '-p, --pretty-print',
+      help: 'force pretty printing even if invalid'
     }
   }).parse();
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -128,7 +128,7 @@ function schemaError (str, err) {
          "\ndetails: " + JSON.stringify(err.details);
 }
 
-function main (args) {
+function main () {
   var source = '';
   if (options.file) {
     var json = path.normalize(options.file);
@@ -176,4 +176,4 @@ function sortObject(o) {
   return sorted;
 }
 
-main(process.argv.slice(1));
+main();

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,0 +1,111 @@
+var LINE_FEED = process.platform === 'win32' ? '\r\n' : '\n';
+
+function printContext(lines, errorLineNumber, contextWindow, fileName) {
+  var firstLine = errorLineNumber - contextWindow;
+  if (firstLine < 0) {
+    firstLine = 0;
+  } else if (firstLine >= lines.length) {
+      firstLine = lines.length - 1;
+  }
+  var lastLine = errorLineNumber + contextWindow;
+  if (lastLine >= lines.length) {
+    lastLine = lines.length - 1;
+  }
+  console.log('--- ' + fileName + ': ' + firstLine + ', ' + lastLine + ' ---');
+  for (var line = firstLine; line <= lastLine; ++line) {
+    if (line === errorLineNumber && contextWindow !== 0) {
+      console.log('!' + lines[line]);
+    } else {
+      console.log(' ' + lines[line]);
+    }
+  }
+}
+
+function parseIntArg (argName, potentialInt, min, max) {
+  var result;
+  if (typeof potentialInt === 'number') {
+    result = Math.floor(potentialInt);
+  } else {
+    result = parseInt(potentialInt, 10);
+  }
+
+  if (isNaN(result)) {
+    throw new Error('"' + potentialInt + '" is not a valid number for "' + argName + '"!');
+  } else if ((min !== undefined && result < min) || (max !== undefined && result > max)) {
+    throw new Error('"' + result + '" is not in the range between >= ' + min + ' and <= ' + max + ' for "' + argName + '"!');
+  }
+
+  return result;
+}
+
+function printDiff (linesSource, errorLineNumberSource, linesResult, errorLineNumberResult, options) {
+  var contextWindow;
+  try {
+    contextWindow = parseIntArg('--diff-context', options.diffContext);
+  } catch (err) {
+    contextWindow = 0;
+  }
+  printContext(linesSource, errorLineNumberSource, contextWindow, 'source');
+  printContext(linesResult, errorLineNumberResult, contextWindow, 'result');
+}
+
+function makeDiff (source, result, options) {
+  var ignoreEmptyLines;
+  try {
+    ignoreEmptyLines = parseIntArg('--ignore-empty-lines', options.ignoreEmptyLines);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  var ignoreTrailingNewLines;
+  try {
+    ignoreTrailingNewLines = parseIntArg('--ignore-trailing-newlines', options.ignoreTrailingNewLines);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  var linesSource = source.split(LINE_FEED);
+  var linesResult = result.split(LINE_FEED);
+  var consecutiveEmptyLinesFound = 0;
+  var lineNumberSource = 0;
+  var lineNumberResult = 0;
+  while (lineNumberSource !== linesSource.length && lineNumberResult !== linesResult.length) {
+    if (linesSource[lineNumberSource] !== linesResult[lineNumberResult]) {
+      if (linesSource[lineNumberSource].length === 0 &&
+          consecutiveEmptyLinesFound < ignoreEmptyLines) {
+        ++consecutiveEmptyLinesFound;
+        ++lineNumberSource;
+      } else {
+        break;
+      }
+    } else {
+      consecutiveEmptyLinesFound = 0;
+      ++lineNumberSource;
+      ++lineNumberResult;
+    }
+  }
+
+  var trailingEmptyLinesFound = 0;
+  if (lineNumberSource < linesSource.length) {
+    for (var pos = lineNumberSource; pos !== linesSource.length; ++pos) {
+      if (linesSource[pos] === '') {
+        ++trailingEmptyLinesFound;
+      } else {
+        trailingEmptyLinesFound = 0;
+        break;
+      }
+    }
+  }
+
+  if (lineNumberSource === linesSource.length ||
+      (trailingEmptyLinesFound > 0 && trailingEmptyLinesFound <= ignoreTrailingNewLines)) {
+    process.exit(0);
+  } else {
+    if (!options.quiet) {
+      printDiff(linesSource, lineNumberSource, linesResult, lineNumberResult, options);
+    }
+    process.exit(1);
+  }
+}
+
+module.exports = exports = makeDiff;


### PR DESCRIPTION
This allows to compare the output with the input data. In addition to validate only the semantics of the JSON data a diff-like feature also allows to validate the style of the data (e.g. spacing). This means it can be used in an automated build chain that also checks .json files for style rules based on jsonlint.

The following feature are offered:

exits with 0 and no content on stdout in case of success if called with --diff
exists with 1 and a diff-like output on stdout if --quiet is not set but --diff is set
exists with 1 and not output on stdout if --quiet and --diff is set
allows to set the context window (in lines) that is printed in error case
allows to ignore n trailing line feed in the source to be compliant to the output
allows to ignore n empty lines in the source file
