### PR TITLE
Remove preferGlobal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "lint",
     "jsonlint"
   ],
-  "version": "1.6.2",
-  "preferGlobal": true,
+  "version": "1.6.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/zaach/jsonlint.git"


### PR DESCRIPTION
This line causes a WARN message on installs when jsonlint is used as a dependency in other projects.  The line is not necessary and other projects such as jshint have removed this as well.