### PR TITLE
chore: add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "jsonlint"
   ],
   "version": "1.6.2",
+  "license": "MIT",
   "preferGlobal": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
The license should be set in package.json.