### PR TITLE
[HOTFIX] Use ^ in package.json versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "nomnom": ">= 1.5.x",
-    "JSV": ">= 4.0.x"
+    "nomnom": "^1.5.x",
+    "JSV": "^4.0.x"
   },
   "devDependencies": {
     "test": "*",


### PR DESCRIPTION
This ensures that semver-major upgrades don't get pulled in.

This became a critical bug recently because npm decided to publish a placeholder package as nomnom@2, causing *all new installs* of jsonlint to crash. See https://www.npmjs.com/package/nomnom, https://travis-ci.org/pump-io/pump.io/jobs/342947005