### PR TITLE
Add ALE to list of Vim plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ It returns the parsed object or throws an `Error`.
 ## Vim Plugins
 
 * [Syntastic](http://www.vim.org/scripts/script.php?script_id=2736)
-* [sourcebeautify](http://www.vim.org/scripts/script.php?script_id=4079) 
+* [sourcebeautify](http://www.vim.org/scripts/script.php?script_id=4079)
+* [ALE](https://github.com/w0rp/ale)
 
 ## MIT License
 


### PR DESCRIPTION
ALE, which is a Vim plugin to run linters asynchronously, supports jsonlint.

https://github.com/w0rp/ale/blob/master/doc/ale.txt#L132

I added it to the list of Vim plugins.