### PR TITLE
Adds prevents fs from attempting to load in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "test": "node test/all-tests.js"
   },
   "homepage": "http://zaach.github.com/jsonlint/",
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "browser": {
+    "fs": false
+  }
 }


### PR DESCRIPTION
This fixes issue with angular compilation (because of inability to edit webpack config) when this package is being used. This flag has no negative effect on the package itself, and allows it to be readily compatible with webpack or other bundlers