### PR TITLE
Replace nomnom with commander

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@ var parser = require("./jsonlint").parser;
 var JSV = require("JSV").JSV;
 var formatter = require("./formatter.js").formatter;
 
-var options = require("nomnom")
+var options = require("commander")
   .script("jsonlint")
   .options({
     file: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,16 +31,18 @@
     "ansi-styles": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+      "dev": true
     },
     "chalk": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
       "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "dev": true,
       "requires": {
-        "ansi-styles": "1.0.0",
-        "has-color": "0.1.7",
-        "strip-ansi": "0.1.1"
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
       }
     },
     "cjson": {
@@ -59,10 +61,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
-      "dev": true
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
     },
     "ebnf-parser": {
       "version": "0.1.10",
@@ -76,10 +77,10 @@
       "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
       "dev": true,
       "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "esprima": "~1.1.1",
+        "estraverse": "~1.5.0",
+        "esutils": "~1.0.0",
+        "source-map": "~0.1.33"
       }
     },
     "esprima": {
@@ -103,7 +104,8 @@
     "has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
     },
     "jison": {
       "version": "0.4.18",
@@ -114,10 +116,10 @@
         "JSONSelect": "0.4.0",
         "cjson": "0.3.0",
         "ebnf-parser": "0.1.10",
-        "escodegen": "1.3.3",
-        "esprima": "1.1.1",
-        "jison-lex": "0.3.4",
-        "lex-parser": "0.1.4",
+        "escodegen": "1.3.x",
+        "esprima": "1.1.x",
+        "jison-lex": "0.3.x",
+        "lex-parser": "~0.1.3",
         "nomnom": "1.5.2"
       },
       "dependencies": {
@@ -127,8 +129,8 @@
           "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
           "dev": true,
           "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.1.7"
+            "colors": "0.5.x",
+            "underscore": "1.1.x"
           }
         },
         "underscore": {
@@ -145,7 +147,7 @@
       "integrity": "sha1-gcoo2E+ESZ36jFlNzePYo/Jux6U=",
       "dev": true,
       "requires": {
-        "lex-parser": "0.1.4",
+        "lex-parser": "0.1.x",
         "nomnom": "1.5.2"
       },
       "dependencies": {
@@ -155,8 +157,8 @@
           "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
           "dev": true,
           "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.1.7"
+            "colors": "0.5.x",
+            "underscore": "1.1.x"
           }
         },
         "underscore": {
@@ -173,8 +175,8 @@
       "integrity": "sha1-iKpGvCiaesk7tGyuLVihh6m7SUo=",
       "dev": true,
       "requires": {
-        "JSV": "4.0.2",
-        "nomnom": "1.8.1"
+        "JSV": ">= 4.0.x",
+        "nomnom": ">= 1.5.x"
       }
     },
     "lex-parser": {
@@ -187,9 +189,10 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
       }
     },
     "source-map": {
@@ -199,13 +202,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "strip-ansi": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+      "dev": true
     },
     "test": {
       "version": "0.6.0",
@@ -222,10 +226,16 @@
       "integrity": "sha512-AKLsYcdV+sS5eAE4NtVXF6f2u/DCQynQm0jTGxF261+Vltu1dYNuHzjqDmk11gInj+H/zJIM2EAwXG3MzPb3VA==",
       "dev": true,
       "requires": {
-        "commander": "2.14.1",
-        "source-map": "0.6.1"
+        "commander": "~2.14.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -237,7 +247,8 @@
     "underscore": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
-    "nomnom": "^1.5.x",
+    "commander": "^2.18.0",
     "JSV": "^4.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Recommended migration path from `nomnom`: https://github.com/harthur/nomnom/blob/master/README.md

Resolves https://github.com/zaach/jsonlint/issues/103

https://github.com/zaach/jison/pull/367 also needs a merge to remove `nomnom` from the dependency chain.