### PR TITLE
Add introduction to a successor project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ JSON Lint
 
 A pure [JavaScript version](http://zaach.github.com/jsonlint/) of the service provided at [jsonlint.com](http://jsonlint.com).
 
+This project is unmaintained and see [a successor project with some improvements: jsonlint-cli](https://github.com/marionebl/jsonlint-cli), if you need multiple files support or more.
+
 ## Command line interface
 Install jsonlint with npm to use the command line interface:
 


### PR DESCRIPTION
I've tried to use this command with multiple files and found the issue #77. Sadly a pull request about the issue is not merged and I've realized a successor project forked from this is already available as `jsonlint-cli`.

This `jsonlint` npm module is well-known and found as the first choice when I search the web with keywords like "json lint npm". But actually this project is unmaintained for two years, thus I think an introduction to any successor project from the front page will make new comers happy. How about this idea?