### PR TITLE
Expose jsonlint as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+---
+
+# For use with pre-commit.
+# See usage instructions at http://pre-commit.com
+
+- id: jsonlint
+  name: jsonlint
+  description: This hook runs jsonlint
+  entry: bash -c 'for x in "$@"; do jsonlint --quiet --compact "$x"; done' --
+  language: node
+  files: '^.*\.json$'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ It returns the parsed object or throws an `Error`.
 ## Vim Plugins
 
 * [Syntastic](http://www.vim.org/scripts/script.php?script_id=2736)
-* [sourcebeautify](http://www.vim.org/scripts/script.php?script_id=4079) 
+* [sourcebeautify](http://www.vim.org/scripts/script.php?script_id=4079)
+
+## Usage with pre-commit
+
+**jsonlint** can be used as a hook for [pre-commit](https://pre-commit.com/) tool.
+The easiest way to get started is to add this configuration to your `.pre-commit-config.yaml`.
+
+    repos:
+      - repo: https://github.com/zaach/jsonlint
+        rev: master
+        hooks:
+          - id: jsonlint
 
 ## MIT License
 


### PR DESCRIPTION
Adds hook definition so jsonlint can be used to lint JSON files by users of pre-commit tool.