### PR TITLE
Add Continuous Integration section in README + Mega-Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ It returns the parsed object or throws an `Error`.
 * [Syntastic](http://www.vim.org/scripts/script.php?script_id=2736)
 * [sourcebeautify](http://www.vim.org/scripts/script.php?script_id=4079) 
 
+## Continuous Integration
+
+* [Mega-Linter](https://nvuillam.github.io/mega-linter/)
+  * embeds more than 70 linters, including [jsonlint](https://nvuillam.github.io/mega-linter/descriptors/json_jsonlint/) by default in all its [flavors](https://nvuillam.github.io/mega-linter/flavors/), so any detected JSON file will be linted by jsonlint
+  * Runnable in CI as [GitHub Action and in other CI tools]((https://nvuillam.github.io/mega-linter/installation/))
+  * can can also be [run locally](https://nvuillam.github.io/mega-linter/mega-linter-runner/)
+
 ## MIT License
 
 Copyright (C) 2012 Zachary Carter


### PR DESCRIPTION
Thanks for your linter, it works like a charm :)

I integrated it in [Mega-Linter](https://nvuillam.github.io/mega-linter/), would it be ok to add the reference in your README ?

jsonlint info in mega-linter doc is here -> https://nvuillam.github.io/mega-linter/descriptors/json_jsonlint/



